### PR TITLE
Fixed Plotly chart size issue. Removed default

### DIFF
--- a/src/FsLab.Runner/Formatters.fs
+++ b/src/FsLab.Runner/Formatters.fs
@@ -230,8 +230,6 @@ let wrapFsiEvaluator root output (floatFormat:string) (fsiEvaluator:FsiEvaluator
           match fig.Layout with
           | Some ly -> ly.title
           | None -> sprintf "XPlot Generated Chart %d" (imageCounter())
-        fig.Width <- 600
-        fig.Height <- 300
         Some [ InlineBlock (fig.GetInlineHtml(name)) ]
 
     | :? ChartTypes.GenericChart as ch ->

--- a/src/FsLab.fsx
+++ b/src/FsLab.fsx
@@ -102,8 +102,6 @@ module FsiAutoShow =
       match chart.Layout with
       | Some ly -> ly.title
       | None -> sprintf "XPlot Generated Chart %d" counter.Value
-    chart.Width <- 800
-    chart.Height <- 600
     """<!DOCTYPE html>
     <html>
     <head><title>Plotly Chart</title></head>


### PR DESCRIPTION
Removed figure width and height for Plotly charts from
FsLab.fsx bootstrapper script and Formatter.fs
in FsLab runner.  XPlot Plotly chart default size
is 900x500 pixels.