### PR TITLE
Add journal extension support for VS2012 and VS2015

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,3 +27,4 @@
 * 0.3.3 - Update JSON.NET and other references (to avoid NuGet resolve issues)
 * 0.3.4 - Fixed Plotly chart size issue. Removed default (#91, #93)
 * 0.3.5 - Update Deedle (including BigDeedle release)
+* 0.3.6 - Add journal extension support for Visual Studio 2015 (#82)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,4 +27,4 @@
 * 0.3.3 - Update JSON.NET and other references (to avoid NuGet resolve issues)
 * 0.3.4 - Fixed Plotly chart size issue. Removed default (#91, #93)
 * 0.3.5 - Update Deedle (including BigDeedle release)
-* 0.3.6 - Add journal extension support for Visual Studio 2015 (#82)
+* 0.3.6 - Add journal extension support for Visual Studio 2012 and 2015 (#23, #82)

--- a/src/template/Properties/AssemblyInfo.cs
+++ b/src/template/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("FsLab.Template")]
@@ -14,20 +14,20 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/src/template/source.extension.vsixmanifest
+++ b/src/template/source.extension.vsixmanifest
@@ -10,7 +10,7 @@
     <Tags>f# data science fslab</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[12.0,15.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,12.0,15.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/src/template/source.extension.vsixmanifest
+++ b/src/template/source.extension.vsixmanifest
@@ -10,7 +10,7 @@
     <Tags>f# data science fslab</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[12.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[12.0,15.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
This is in reference to issues #23 and #82 

The only real change here was to add the missing VS version numbers to src/template/source.extension.vsixmanifest and compile. First attempt to install this into VS2015 Enterprise went off without a hitch, and basic functionality was tested successfully. I don't have a copy of VS2012 installed right now, so I'd love for somebody to test it on my behalf.